### PR TITLE
docs: add Getting Started section to README for Python/Poetry setup and quick run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ You can install the Ancestry Prediction tool using poetry. Make sure that you ha
 poetry add https://github.com/genxnetwork/flan/
 ```
 
+## Getting Started
+
+1. Verify prerequisites:
+   - `python3 --version` (should be 3.9+)
+   - `poetry --version`
+2. From repo root:
+   - `poetry install`
+   - `poetry shell` (or use `poetry run` for each command)
+3. Run a quick local workflow:
+   - `flan global fit`
+   - `flan global predict --file=path/to/your_sample.vcf.gz`
+
 ## Usage
 
 To fit the model globally, use the following command:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ poetry add https://github.com/genxnetwork/flan/
    - `poetry --version`
 2. From repo root:
    - `poetry install`
-   - `poetry shell` (or use `poetry run` for each command)
-3. Run a quick local workflow:
+   - `poetry shell` (activates the virtual environment; alternatively, prefix commands with `poetry run`)
+3. Run a quick local workflow (ensure you're in the Poetry environment):
    - `flan global fit`
-   - `flan global predict --file=path/to/your_sample.vcf.gz`
+   - `flan global predict --file=path/to/your_sample.vcf.gz` (use a sample VCF file from the repo's data directory or your own genomic data in VCF format)
 
 ## Usage
 


### PR DESCRIPTION
Added a "Getting Started" section to the README.md to guide new users through initial setup and a basic workflow. 
This includes verifying Python 3.9+ and Poetry installation, running poetry install, and executing sample commands like flan global fit and flan global predict. 
The update reduces onboarding friction by providing clear, actionable steps before the detailed Usage section.

## Summary by Sourcery

Add an introductory Getting Started section to the README to guide new users through basic Python/Poetry setup and a simple local workflow.

Documentation:
- Document prerequisite checks for Python 3.9+ and Poetry, and outline initial install and shell commands for running the tool.
- Add quick-start examples for fitting and predicting globally using the CLI to streamline onboarding.